### PR TITLE
Allow setting USERNAME and PASSWORD with docker secrets

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,34 @@
 
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+        local var="$1"
+        local fileVar="${var}_FILE"
+        local def="${2:-}"
+        if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+                echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+                exit 1
+        fi
+        local val="$def"
+        if [ "${!var:-}" ]; then
+                val="${!var}"
+        elif [ "${!fileVar:-}" ]; then
+                val="$(< "${!fileVar}")"
+        fi
+        export "$var"="$val"
+        unset "$fileVar"
+}
+
+# Get PASSWORD from PASSWORD_FILE if available
+file_env 'PASSWORD'
+
+# Get USERNAME from USERNAME_FILE if availabile
+file_env 'USERNAME'
+
 if [ "${CRON_SCHEDULE}" ]; then
     exec go-cron -s "0 ${CRON_SCHEDULE}" -- automysqlbackup
 else


### PR DESCRIPTION
This still allows using PASSWORD or USERNAME, but if passed via environment with _FILE appended it will use those

docker-compose.yml example snippet:
secrets:
  mysql_root_password:
    file: "secrets/db/mysql_root_password"

  mysqlbackup:
    secrets:
      - mysql_root_password
    environment:
      USERNAME: root
      PASSWORD_FILE: /run/secrets/mysql_root_password