### PR TITLE
Remove  `column-statistics` from mysql 5.7 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN mkdir -p /etc/default /etc/mysql
 
 COPY --from=builder /go/src/github.com/odise/go-cron/go-cron /usr/local/bin/
 COPY automysqlbackup start.sh /usr/local/bin/
-COPY my.cnf /etc/mysql/
 
 RUN chmod +x /usr/local/bin/go-cron \
     /usr/local/bin/automysqlbackup \

--- a/my.cnf
+++ b/my.cnf
@@ -1,2 +1,0 @@
-[mysqldump]
-# column-statistics=0

--- a/my.cnf
+++ b/my.cnf
@@ -1,2 +1,2 @@
 [mysqldump]
-column-statistics=0
+# column-statistics=0


### PR DESCRIPTION
Comment  `column-statistics` in `my.cnf`  because in mysql 5.7 it generate an error :
```
mysqldump: [ERROR] unknown variable 'column-statistics=0'
```